### PR TITLE
Yield to event loop when synchronous work takes too long

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
       "@babel/preset-react"
     ]
   },
+  "jest": {
+    "globals": {
+      "__DEV__": true
+    }
+  },
   "lint-staged": {
     "**/*.js": [
       "flow focus-check",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "prettier": "^1.16.4",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
-    "react-is": "^16.8.4"
+    "react-is": "^16.8.4",
+    "styled-components": "^4.2.0"
   },
   "dependencies": {
     "object-is": "^1.0.1"

--- a/src/__tests__/suspense.test.js
+++ b/src/__tests__/suspense.test.js
@@ -18,7 +18,7 @@ describe('renderPrepass', () => {
 
       const Outer = () => {
         const start = Date.now()
-        while (Date.now() - start < 11) {}
+        while (Date.now() - start < 6) {}
         return <Inner />
       }
 

--- a/src/__tests__/suspense.test.js
+++ b/src/__tests__/suspense.test.js
@@ -12,6 +12,40 @@ import React, {
 import renderPrepass from '..'
 
 describe('renderPrepass', () => {
+  describe('event loop yielding', () => {
+    it('yields to the event loop when work is taking too long', () => {
+      const Inner = jest.fn(() => null)
+
+      const Outer = () => {
+        const start = Date.now()
+        while (Date.now() - start < 11) {}
+        return <Inner />
+      }
+
+      const render$ = renderPrepass(<Outer />)
+
+      expect(Inner).toHaveBeenCalledTimes(0)
+
+      setImmediate(() => {
+        setImmediate(() => {
+          expect(Inner).toHaveBeenCalledTimes(1)
+        })
+      })
+
+      return render$.then(() => {
+        expect(Inner).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    it('does not yields when work is below the threshold', () => {
+      const Inner = jest.fn(() => null)
+      const Outer = () => <Inner />
+      const render$ = renderPrepass(<Outer />)
+
+      expect(Inner).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('function components', () => {
     it('supports suspending subtrees', () => {
       const value = {}

--- a/src/__tests__/suspense.test.js
+++ b/src/__tests__/suspense.test.js
@@ -18,7 +18,7 @@ describe('renderPrepass', () => {
 
       const Outer = () => {
         const start = Date.now()
-        while (Date.now() - start < 6) {}
+        while (Date.now() - start < 21) {}
         return <Inner />
       }
 

--- a/src/__tests__/visitor.test.js
+++ b/src/__tests__/visitor.test.js
@@ -12,6 +12,7 @@ import React, {
 } from 'react'
 
 import { createPortal } from 'react-dom'
+import styled from 'styled-components'
 
 import {
   Dispatcher,
@@ -103,6 +104,25 @@ describe('visitElement', () => {
     expect(children.length).toBe(2)
     expect(children[0].type).toBe(Noop)
     expect(children[1].type).toBe(Noop)
+  })
+
+  it('walks StyledComponent DOM elements', () => {
+    const Comp = styled.div``
+    const children = visitElement(
+      <Comp>
+        <Noop />
+      </Comp>,
+      [],
+      () => {}
+    )
+    expect(children.length).toBe(1)
+    expect(children[0].type).toBe(Noop)
+  })
+
+  it('walks StyledComponent wrapper elements', () => {
+    const Comp = styled(Noop)``
+    const children = visitElement(<Comp />, [], () => {})
+    expect(children.length).toBe(1)
   })
 
   it('walks Providers and Consumers', () => {

--- a/src/internals/context.js
+++ b/src/internals/context.js
@@ -4,7 +4,8 @@ import type {
   AbstractContext,
   UserElement,
   ContextMap,
-  ContextStore
+  ContextStore,
+  ContextEntry
 } from '../types'
 
 /** The context is kept as a Map from a Context value to the current
@@ -16,8 +17,6 @@ import type {
    before continuing to walk the tree.
    After walking the children they can be restored.
    This way the context recursively restores itself on the way up. */
-
-type ContextEntry = [AbstractContext, mixed]
 
 let currentContextStore: ContextStore = new Map()
 let currentContextMap: ContextMap = {}
@@ -42,12 +41,16 @@ export const flushPrevContextStore = (): void | ContextEntry => {
   return prev
 }
 
-export const restoreContextMap = (prev: ContextMap) => {
-  Object.assign(currentContextMap, prev)
+export const restoreContextMap = (prev: void | ContextMap) => {
+  if (prev !== undefined) {
+    Object.assign(currentContextMap, prev)
+  }
 }
 
-export const restoreContextStore = (prev: ContextEntry) => {
-  currentContextStore.set(prev[0], prev[1])
+export const restoreContextStore = (prev: void | ContextEntry) => {
+  if (prev !== undefined) {
+    currentContextStore.set(prev[0], prev[1])
+  }
 }
 
 export const setCurrentContextMap = (map: ContextMap) => {

--- a/src/types/element.js
+++ b/src/types/element.js
@@ -104,7 +104,9 @@ export type ForwardRefElement = {
   type: {
     render: ComponentType<DefaultProps> & ComponentStatics,
     $$typeof: typeof REACT_FORWARD_REF_TYPE,
-    styledComponentId?: string // styled-components specific property
+    // styled-components specific properties
+    styledComponentId?: string,
+    target?: ComponentType<mixed> | string
   },
   props: DefaultProps,
   $$typeof: typeof REACT_ELEMENT_TYPE

--- a/src/types/element.js
+++ b/src/types/element.js
@@ -103,7 +103,8 @@ export type MemoElement = {
 export type ForwardRefElement = {
   type: {
     render: ComponentType<DefaultProps> & ComponentStatics,
-    $$typeof: typeof REACT_FORWARD_REF_TYPE
+    $$typeof: typeof REACT_FORWARD_REF_TYPE,
+    styledComponentId?: string // styled-components specific property
   },
   props: DefaultProps,
   $$typeof: typeof REACT_ELEMENT_TYPE

--- a/src/types/frames.js
+++ b/src/types/frames.js
@@ -3,8 +3,8 @@
 import type { ComponentType } from 'react'
 import type { Identity } from '../internals'
 import type { LazyComponent } from '../types'
-import type { DefaultProps, ComponentStatics } from './element'
-import type { ContextMap, ContextStore, Hook } from './state'
+import type { ContextMap, ContextStore, ContextEntry, Hook } from './state'
+import type { AbstractElement, DefaultProps, ComponentStatics } from './element'
 
 export type BaseFrame = {
   contextMap: ContextMap,
@@ -35,4 +35,13 @@ export type HooksFrame = BaseFrame & {
   hook: Hook | null
 }
 
-export type Frame = ClassFrame | HooksFrame | LazyFrame
+/** Description of a pause to yield to the event loop */
+export type YieldFrame = BaseFrame & {
+  kind: 'frame.yield',
+  children: AbstractElement[][],
+  index: number[],
+  map: Array<void | ContextMap>,
+  store: Array<void | ContextEntry>
+}
+
+export type Frame = ClassFrame | HooksFrame | LazyFrame | YieldFrame

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -4,6 +4,7 @@ import type { AbstractContext } from './element'
 
 export type ContextStore = Map<AbstractContext, mixed>
 export type ContextMap = { [name: string]: mixed }
+export type ContextEntry = [AbstractContext, mixed]
 
 export type Dispatch<A> = A => void
 

--- a/src/visitor.js
+++ b/src/visitor.js
@@ -128,11 +128,18 @@ export const visitElement = (
 
     case REACT_FORWARD_REF_TYPE: {
       const refElement = ((element: any): ForwardRefElement)
-      // Treat inner type as the component instead of React.forwardRef itself
-      const type = refElement.type.render
-      const props = refElement.props
-      const child = mountFunctionComponent(type, props, queue, visitor)
-      return getChildrenArray(child)
+      if (typeof refElement.type.styledComponentId === 'string') {
+        // This is an optimization that's specific to styled-components
+        // We can safely skip them and return their children
+        return getChildrenArray(refElement.props.children)
+      } else {
+        const {
+          props,
+          type: { render }
+        } = refElement
+        const child = mountFunctionComponent(render, props, queue, visitor)
+        return getChildrenArray(child)
+      }
     }
 
     case REACT_ELEMENT_TYPE: {

--- a/src/visitor.js
+++ b/src/visitor.js
@@ -58,6 +58,10 @@ import {
   REACT_LAZY_TYPE
 } from './symbols'
 
+// Time in ms after which the otherwise synchronous visitor yields so that
+// the event loop is not interrupted for too long
+const YIELD_AFTER_MS = __DEV__ ? 20 : 5
+
 const render = (
   type: ComponentType<DefaultProps> & ComponentStatics,
   props: DefaultProps,
@@ -172,7 +176,7 @@ const visitLoop = (
 ) => {
   const start = Date.now()
 
-  while (traversalChildren.length > 0 && Date.now() - start <= 5) {
+  while (traversalChildren.length > 0 && Date.now() - start <= YIELD_AFTER_MS) {
     const currChildren = traversalChildren[traversalChildren.length - 1]
     const currIndex = traversalIndex[traversalIndex.length - 1]++
 

--- a/src/visitor.js
+++ b/src/visitor.js
@@ -132,9 +132,12 @@ export const visitElement = (
 
     case REACT_FORWARD_REF_TYPE: {
       const refElement = ((element: any): ForwardRefElement)
-      if (typeof refElement.type.styledComponentId === 'string') {
+      if (
+        typeof refElement.type.styledComponentId === 'string' &&
+        typeof refElement.type.target !== 'function'
+      ) {
         // This is an optimization that's specific to styled-components
-        // We can safely skip them and return their children
+        // We can safely skip them if they're not wrapping a component
         return getChildrenArray(refElement.props.children)
       } else {
         const {

--- a/yarn.lock
+++ b/yarn.lock
@@ -716,6 +716,23 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@emotion/is-prop-valid@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz#a6bf4fa5387cbba59d44e698a4680f481a8da6cc"
+  integrity sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==
+  dependencies:
+    "@emotion/memoize" "0.7.1"
+
+"@emotion/memoize@0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
+  integrity sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==
+
+"@emotion/unitless@^0.7.0":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
+  integrity sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg==
+
 "@jest/console@^24.3.0":
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.3.0.tgz#7bd920d250988ba0bf1352c4493a48e1cb97671e"
@@ -1241,6 +1258,21 @@ babel-plugin-jest-hoist@^24.3.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
+"babel-plugin-styled-components@>= 1":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz#ff1f42ad2cc78c21f26b62266b8f564dbc862939"
+  integrity sha512-sQVKG8irFXx14ZfaK1bBePirfkacl3j8nZwSZK+ZjsbnadRHKQTbhXbe/RB1vT6Vgkz45E+V95LBq4KqdhZUNw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.10"
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
+
 babel-plugin-transform-async-to-promises@^0.8.3:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.5.tgz#8d9817a4a99d36df57616857650522b7c2be511c"
@@ -1469,6 +1501,11 @@ camelcase@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.2.0.tgz#e7522abda5ed94cc0489e1b8466610e88404cf45"
   integrity sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==
+
+camelize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-api@^1.5.2:
   version "1.6.1"
@@ -1797,6 +1834,11 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
+
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -1845,6 +1887,15 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-to-react-native@^2.2.2:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.0.tgz#bf80d24ec4a08e430306ef429c0586e6ed5485f7"
+  integrity sha512-IhR7bNIrCFwbJbKZOAjNDZdwpsbjTN6f1agXeELHDqg1wHPA8c2QLruttKOW7hgMGetkfraRJCIEMrptifBfVw==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^3.3.0"
 
 css-tree@1.0.0-alpha.28:
   version "1.0.0-alpha.28"
@@ -4262,6 +4313,11 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
+memoize-one@^5.0.0:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.4.tgz#005928aced5c43d890a4dfab18ca908b0ec92cbc"
+  integrity sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA==
+
 memorystream@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
@@ -5619,7 +5675,7 @@ prompts@^2.0.1:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
 
-prop-types@^15.6.2:
+prop-types@^15.5.4, prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -5718,6 +5774,11 @@ react-dom@^16.8.4:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.4"
+
+react-is@^16.6.0:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-is@^16.8.1, react-is@^16.8.4:
   version "16.8.4"
@@ -6637,6 +6698,23 @@ style-inject@^0.3.0:
   resolved "https://registry.yarnpkg.com/style-inject/-/style-inject-0.3.0.tgz#d21c477affec91811cc82355832a700d22bf8dd3"
   integrity sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==
 
+styled-components@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.2.0.tgz#811fbbec4d64c7189f6c7482b9eb6fefa7fefef7"
+  integrity sha512-L/LzkL3ZbBhqIVHdR7DbYujy4tqvTNRfc+4JWDCYyhTatI+8CRRQUmdaR0+ARl03DWsfKLhjewll5uNLrqrl4A==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/is-prop-valid" "^0.7.3"
+    "@emotion/unitless" "^0.7.0"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^2.2.2"
+    memoize-one "^5.0.0"
+    prop-types "^15.5.4"
+    react-is "^16.6.0"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+    supports-color "^5.5.0"
+
 stylehacks@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-4.0.3.tgz#6718fcaf4d1e07d8a1318690881e8d96726a71d5"
@@ -6645,6 +6723,16 @@ stylehacks@^4.0.0:
     browserslist "^4.0.0"
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
+
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
+
+stylis@^3.5.0:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
+  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -6658,7 +6746,7 @@ supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==


### PR DESCRIPTION
This implements a new "suspense frame" for yielding to the event loop, called a `YieldFrame`.

The problem with `react-ssr-prepass`' current visiting strategy is that like with `react-dom`'s `renderToString` we never yield to the event loop. When a large app is rendered a lot of the work happens synchronously and blocks anything else from happening, even if the user chooses to use `renderToNodeStream`.

This reimplements the visitor to not be recursive and keep its own state. It then yields when visiting elements has been taking longer than `10ms`. It does this by putting a `YieldFrame` onto the suspense queue that preserves the visitor's state and returns to the visitor like with other suspense frames.