### PR TITLE
peerDependencies on react should be 16.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     }
   },
   "peerDependencies": {
-    "react": "^16.6.0",
-    "react-is": "^16.6.0"
+    "react": "^16.8.0",
+    "react-is": "^16.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.3.4",


### PR DESCRIPTION
Correct me if I'm wrong, but your library is depending on certain features of react 16.8.x (see error below), therefore the peer-dependency on react should be at least 16.8.x.

error:
```
var prevDispatcher = ReactCurrentDispatcher.current;
                                            ^
TypeError: Cannot read property 'current' of undefined
```

Have a look at the following codesandbox: https://codesandbox.io/s/pmyvpmnxw0

I came across this issue due to `next-server` depending on your library, see related issue: https://github.com/zeit/next.js/issues/7073