### PR TITLE
Check whether React internals exist before setting up dispatcher

### DIFF
--- a/src/internals/dispatcher.js
+++ b/src/internals/dispatcher.js
@@ -26,7 +26,8 @@ export const setCurrentIdentity = (id: Identity | null) => {
 export const getCurrentIdentity = (): Identity => {
   if (currentIdentity === null) {
     throw new Error(
-      '[react-ssr-prepass] Hooks can only be called inside the body of a function component. ' +
+      '[react-ssr-prepass] Hooks can only be called ' +
+        'inside the body of a function component. ' +
         '(https://fb.me/react-invalid-hook-call)'
     )
   }
@@ -305,6 +306,8 @@ function useCallback<T>(callback: T, deps: Array<mixed> | void | null): T {
 
 function noop(): void {}
 
+// The "Dispatcher" is what handles hook calls and needs to be set up before
+// visiting children (see ./react.js)
 export const Dispatcher = {
   readContext,
   useContext,

--- a/src/internals/index.js
+++ b/src/internals/index.js
@@ -2,3 +2,4 @@
 
 export * from './context'
 export * from './dispatcher'
+export * from './react'

--- a/src/internals/react.js
+++ b/src/internals/react.js
@@ -1,0 +1,35 @@
+// @flow
+
+import React from 'react'
+import { Dispatcher } from './dispatcher'
+
+type ReactCurrentDispatcher = {
+  current: null | typeof Dispatcher
+}
+
+type SecretInternals = {
+  ReactCurrentDispatcher: ReactCurrentDispatcher
+}
+
+const internals: void | SecretInternals = (React: any)
+  .__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+
+let prevDispatcher: null | typeof Dispatcher
+
+export const hasReactInternals: boolean = internals !== undefined
+
+// This is called before visiting children, so that function
+// components can execute hooks
+export const setupDispatcher = () => {
+  if (internals !== undefined) {
+    prevDispatcher = internals.ReactCurrentDispatcher.current
+    internals.ReactCurrentDispatcher.current = Dispatcher
+  }
+}
+
+// After visiting children the dispatcher is restored
+export const restoreDispatcher = () => {
+  if (internals !== undefined) {
+    internals.ReactCurrentDispatcher.current = prevDispatcher
+  }
+}


### PR DESCRIPTION
`react-ssr-prepass` may be used in cases where `react` has been replaced with `preact`. In such a case, `react-ssr-prepass` should bail without erroring, since the user has explicitly indicated by replacing `react` that the prepass should not run.

This sets up a `react.js` file which is responsible for:

- checking whether the React internals exist
- setting up the dispatcher
- restoring the dispatcher

When the React internals aren't present, `react-ssr-prepass` bails immediately and resolves.

See for more context: https://twitter.com/marvinhagemeist/status/1126451639118909446