### PR TITLE
Fix forwardRef component nested with a memo HOC

### DIFF
--- a/src/__tests__/visitor.test.js
+++ b/src/__tests__/visitor.test.js
@@ -215,7 +215,7 @@ describe('visitElement', () => {
   })
 
   it('walks over memo components', () => {
-    const Test = React.memo(() => <Noop />)
+    const Test = React.memo(Noop)
     const children = visitElement(<Test />, [], () => {})
     expect(children.length).toBe(1)
     expect(children[0].type).toBe(Noop)

--- a/src/visitor.js
+++ b/src/visitor.js
@@ -134,8 +134,7 @@ export const visitElement = (
     case REACT_MEMO_TYPE: {
       const memoElement = ((element: any): MemoElement)
       const type = memoElement.type.type
-      const fauxElement = (createElement((type: any), memoElement.props): any)
-      const child = render(type, memoElement.props, queue, visitor, fauxElement)
+      const child = createElement((type: any), memoElement.props)
       return getChildrenArray(child)
     }
 


### PR DESCRIPTION
Fix https://github.com/framer/motion/issues/256

This bug was discovered by running `react-ssr-prepass` over the `motion` codebase; See: https://github.com/framer/motion/blob/b0dcfa8/src/motion/utils/use-motion-values.ts#L175

The bug can be reproduced with any component nested in a `forwardRef` component then nested in a `memo` higher-order component:

```js
memo(forwardRef(SomeComponent))
```

The visitor for `memo` components erroneously assumes that the nested `type` can only be a class or function component. It entirely ignores other types of "special" components like a `forwardRef` component.

The fix is to remove this special path and instead return an element from the `memo` component's nested `type`. This will correctly return a `forwardRef` element.
component visitor.