### PR TITLE
Fix syntax error in Flow type definition

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -6,6 +6,6 @@ export type Visitor = (
 ) => void | Promise<any>
 
 declare module.exports: (
-  node: React$Node
+  node: React$Node,
   visitor?: Visitor
 ) => Promise<void>;


### PR DESCRIPTION
This currently has a syntax error ([Try Flow](https://flow.org/try/#0PQKgBAAgZgNg9gdzAZwC4CcCWBjVYTABQhApgB4AOc6eqAnhSWAGqbKarVgC8YAFITBgSMEgFsSAO1QAuMACUSAQ1wASAKKiJ0gDxLJdAHwAaQWEyS0+7CQD8cxStSqAwnDFVJU1HoPGw+kaEAJQ8hmAAbnCYACZgAD5gAAro7mwkvkGEMSTYMEroTGJwMQCuogB05FQ0yHICQpIlJA7KagByzWYRbBzU9iy9nOghYcmpYuk6UbGGANxAA))