### PR TITLE
Add TypeScript definitions.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,10 @@
+declare module 'react-ssr-prepass' {
+  type Visitor = (
+    element: React.ElementType<any>,
+    instance?: React.Component<any, any>
+  ) => void | Promise<any>
+
+  function ssrPrepass(node: React.ReactNode, visitor?: Visitor): Promise<void>
+
+  export = ssrPrepass
+}

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
   "files": [
     "index.js",
     "index.js.flow",
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
+  "types": "index.d.ts",
   "scripts": {
     "prepublishOnly": "run-s build",
     "build": "rollup -c rollup.config.js",


### PR DESCRIPTION
Lol I feel like a Mark Dalgliesh meme opening this, but just came across it while adding support for `next-urql` and thought I'd be a good mate and add them. The output from `npm publish --dry-run` indicates they should get included in the tarball published to `npm`.

```
npm notice 
npm notice 📦  react-ssr-prepass@1.0.7
npm notice === Tarball Contents === 
npm notice 2.3kB  package.json                                
npm notice 266B   index.d.ts                                  
npm notice 199B   index.js                                    
npm notice 226B   index.js.flow                               
npm notice 1.1kB  LICENSE                                     
npm notice 7.0kB  README.md                                   
npm notice 24.1kB dist/react-ssr-prepass.development.js       
npm notice 56.7kB dist/react-ssr-prepass.development.js.map   
npm notice 9.2kB  dist/react-ssr-prepass.production.min.js    
npm notice 55.3kB dist/react-ssr-prepass.production.min.js.map
npm notice === Tarball Details === 
npm notice name:          react-ssr-prepass                       
npm notice version:       1.0.7                                   
npm notice package size:  43.7 kB                                 
npm notice unpacked size: 156.3 kB                                
npm notice shasum:        e3034fc19c03b9032bf2f7a1cf2cc95ec47c54e3
npm notice integrity:     sha512-Z8XHHI3e+EW8a[...]CDJkkyAnlusDg==
npm notice total files:   10                                      
npm notice 
+ react-ssr-prepass@1.0.7
```

I don't have permissions to push branches directly unfortunately, so had to fork it.