### PR TITLE
Fix process crash on getting of exception after yield

### DIFF
--- a/src/__tests__/suspense.test.js
+++ b/src/__tests__/suspense.test.js
@@ -37,6 +37,27 @@ describe('renderPrepass', () => {
       })
     })
 
+    it('rejects promise after getting of exception inside', () => {
+      const exception = new TypeError('Something went wrong')
+
+      const Inner = jest.fn(() => {
+        throw exception
+      })
+
+      const Outer = () => {
+        const start = Date.now()
+        while (Date.now() - start < 40) {}
+        return <Inner />
+      }
+
+      const render$ = renderPrepass(<Outer />)
+
+      return render$.catch(error => {
+        expect(Inner).toHaveBeenCalledTimes(1)
+        expect(error).toBe(exception)
+      })
+    })
+
     it('preserves the correct legacy context values across yields', () => {
       let called = false
       const Inner = (_, context) => {

--- a/src/index.js
+++ b/src/index.js
@@ -36,13 +36,17 @@ const updateWithFrame = (
   if (frame.kind === 'frame.yield') {
     const yieldFrame: YieldFrame = frame
 
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       setImmediate(() => {
-        prevDispatcher = ReactCurrentDispatcher.current
-        ReactCurrentDispatcher.current = Dispatcher
-        resumeVisitChildren(yieldFrame, queue, visitor)
-        ReactCurrentDispatcher.current = prevDispatcher
-        resolve()
+        try {
+          prevDispatcher = ReactCurrentDispatcher.current
+          ReactCurrentDispatcher.current = Dispatcher
+          resumeVisitChildren(yieldFrame, queue, visitor)
+          ReactCurrentDispatcher.current = prevDispatcher
+          resolve()
+        } catch (error) {
+          reject(error)
+        }
       })
     })
   }


### PR DESCRIPTION
Exceptions in all asynchronous code should be handled where is that asynchrony created.

Thrown exceptions inside builtin asynchronous functions like `setImmediate`, `setTimeout`, e.t.c. raise directly to process handler (see `uncaughtException` event).


