### PR TITLE
Fix memo component nested in forwardRef HOC

### DIFF
--- a/src/__tests__/visitor.test.js
+++ b/src/__tests__/visitor.test.js
@@ -201,7 +201,7 @@ describe('visitElement', () => {
   })
 
   it('walks over forwardRef components', () => {
-    const Test = React.forwardRef(() => <Noop />)
+    const Test = React.forwardRef(Noop)
     const children = visitElement(<Test />, [], () => {})
     expect(children.length).toBe(1)
     expect(children[0].type).toBe(Noop)

--- a/src/visitor.js
+++ b/src/visitor.js
@@ -136,7 +136,7 @@ export const visitElement = (
 
     case REACT_MEMO_TYPE: {
       const memoElement = ((element: any): MemoElement)
-      const type = memoElement.type.type
+      const { type } = memoElement.type
       const child = createElement((type: any), memoElement.props)
       return getChildrenArray(child)
     }
@@ -152,8 +152,7 @@ export const visitElement = (
 
       const { render: type, defaultProps } = refElement.type
       const props = computeProps(refElement.props, defaultProps)
-      const fauxElement = (createElement((render: any), props): any)
-      const child = render(type, props, queue, visitor, fauxElement)
+      const child = createElement((type: any), props)
       return getChildrenArray(child)
     }
 


### PR DESCRIPTION
Fix #35

This is the same fix as #15, but for the opposite
way around.