### PR TITLE
Fix suspense in useState and useReducer initializers

### DIFF
--- a/src/__tests__/suspense.test.js
+++ b/src/__tests__/suspense.test.js
@@ -224,6 +224,33 @@ describe('renderPrepass', () => {
       })
     })
 
+    it("handles suspenses thrown in useState's initialState initialiser", () => {
+      const getValue = jest
+        .fn()
+        .mockImplementationOnce(() => {
+          throw Promise.resolve()
+        })
+        .mockImplementation(() => 'test')
+
+      const Inner = jest.fn(props => {
+        expect(props.state).toBe('test')
+      })
+
+      const Outer = jest.fn(() => {
+        const [state] = useState(() => {
+          // This will trigger suspense:
+          return getValue()
+        })
+
+        return <Inner state={state} />
+      })
+
+      return renderPrepass(<Outer />).then(() => {
+        expect(Outer).toHaveBeenCalled()
+        expect(Inner).toHaveBeenCalled()
+      })
+    })
+
     it('ignores thrown non-promises', () => {
       const Outer = () => {
         throw new Error('test')
@@ -435,7 +462,7 @@ describe('renderPrepass', () => {
       })
     })
 
-    it('supports rendering previouslt resolved lazy components', () => {
+    it('supports rendering previously resolved lazy components', () => {
       const Inner = jest.fn(() => null)
       const loadInner = jest.fn().mockResolvedValueOnce(Inner)
       const Outer = React.lazy(loadInner)


### PR DESCRIPTION
Fix https://github.com/FormidableLabs/next-urql/issues/34

This fixes an edge case where a suspense is triggered in the `useState` initialiser (`useState(() => throw Promise.resolve())`) or in the `useReducer`'s `init` argument (`useReducer(x, y, () => throw Promise.resolve())`)

This is achieved by ensuring that the hook's state is initialised before applying updates on a rerender, since the `workInProgressHook` will have already been created after suspense.

And subsequently we also fix the initialiser not being called on rerenders by instead checking whether the hook's state has been initialised.