### PR TITLE
Refactor to use `Promise.resolve().then` over `setImmediate`

### DIFF
--- a/src/__tests__/suspense.test.js
+++ b/src/__tests__/suspense.test.js
@@ -26,11 +26,11 @@ describe('renderPrepass', () => {
 
       expect(Inner).toHaveBeenCalledTimes(0)
 
-      setImmediate(() => {
-        setImmediate(() => {
+      Promise.resolve()
+        .then(() => {})
+        .then(() => {
           expect(Inner).toHaveBeenCalledTimes(1)
         })
-      })
 
       return render$.then(() => {
         expect(Inner).toHaveBeenCalledTimes(1)

--- a/src/index.js
+++ b/src/index.js
@@ -50,16 +50,11 @@ const updateWithFrame = (
   visitor: Visitor
 ): Promise<void> => {
   if (frame.kind === 'frame.yield') {
-    return new Promise((resolve, reject) => {
-      setImmediate(() => {
-        try {
-          resumeWithDispatcher(frame, queue, visitor)
-          resolve()
-        } catch (err) {
-          reject(err)
-        }
+    return Promise.resolve() // wait for next tick
+      .then(() => {
+        // promise api note: if this `throw`s, the promise will reject
+        resumeWithDispatcher(frame, queue, visitor)
       })
-    })
   }
 
   return frame.thenable.then(() => {


### PR DESCRIPTION
Closes #48

I could have just replaced `setImmediate` with `Promise.resolve().then` everywhere and it would have worked, but would have introduced some Promise antipatterns. In both cases the answer is refactoring with Promise chains, as I have done here.

Not sure if I needed to add the comments in src/index.js, but I guess they can't hurt. 

In addition to the source code, I updated one jest test with the same change (to use `Promise.resolve().then` over `setImmediate`). Actually I noticed that in this test we only need to wait **one** tick and the test will pass. E.g. if you only use one `setImmediate`, or remove the first `.then` call, the tests will still pass. This was true before my changes to the source code. Anyways I'll leave that with you.