### PR TITLE
Disable `setImmediate` event loop yielding in the browser, 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,10 @@ import {
   Dispatcher
 } from './internals'
 
+// `isServer` will be `true` in node & jest, & `false` in
+// the browser where the bundler shims the `process` object
+const isServer = !process.browser
+
 const {
   ReactCurrentDispatcher
 } = (React: any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
@@ -51,14 +55,15 @@ const updateWithFrame = (
 ): Promise<void> => {
   if (frame.kind === 'frame.yield') {
     return new Promise((resolve, reject) => {
-      setImmediate(() => {
+      const resume = () => {
         try {
           resumeWithDispatcher(frame, queue, visitor)
           resolve()
         } catch (err) {
           reject(err)
         }
-      })
+      }
+      isServer ? setImmediate(resume) : resume()
     })
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,9 +11,10 @@ import {
   Dispatcher
 } from './internals'
 
-// `isServer` will be `true` in node & jest, & `false` in
-// the browser where the bundler shims the `process` object
-const isServer = !process.browser
+// In the presence of setImmediate, i.e. on Node, we'll enable the
+// yielding behavior that gives the event loop a chance to continue
+// running when the prepasses would otherwise take too long
+const SHOULD_YIELD = typeof setImmediate === 'function';
 
 const {
   ReactCurrentDispatcher
@@ -63,7 +64,11 @@ const updateWithFrame = (
           reject(err)
         }
       }
-      isServer ? setImmediate(resume) : resume()
+      if (SHOULD_YIELD) {
+        setImmediate(resume)
+      } else {
+        resume()
+      }
     })
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import React, { type Node, type Element } from 'react'
 import type { Visitor, YieldFrame, Frame, AbstractElement } from './types'
-import { visitChildren, resumeVisitChildren, update } from './visitor'
+import { visitChildren, resumeVisitChildren, update, SHOULD_YIELD } from './visitor'
 import { getChildrenArray } from './element'
 
 import {
@@ -10,11 +10,6 @@ import {
   setCurrentContextMap,
   Dispatcher
 } from './internals'
-
-// In the presence of setImmediate, i.e. on Node, we'll enable the
-// yielding behavior that gives the event loop a chance to continue
-// running when the prepasses would otherwise take too long
-const SHOULD_YIELD = typeof setImmediate === 'function';
 
 const {
   ReactCurrentDispatcher

--- a/src/visitor.js
+++ b/src/visitor.js
@@ -67,6 +67,11 @@ import {
   REACT_LAZY_TYPE
 } from './symbols'
 
+// In the presence of setImmediate, i.e. on Node, we'll enable the
+// yielding behavior that gives the event loop a chance to continue
+// running when the prepasses would otherwise take too long
+export const SHOULD_YIELD = typeof setImmediate === 'function';
+
 // Time in ms after which the otherwise synchronous visitor yields so that
 // the event loop is not interrupted for too long
 const YIELD_AFTER_MS = process.env.NODE_ENV !== 'production' ? 20 : 5
@@ -189,7 +194,7 @@ const visitLoop = (
       restoreContextStore(traversalStore.pop())
     }
 
-    if (Date.now() - start > YIELD_AFTER_MS) {
+    if (SHOULD_YIELD && (Date.now() - start > YIELD_AFTER_MS)) {
       return true
     }
   }


### PR DESCRIPTION
Closes #48

To define `isServer` we can't use a simple `typeof window === 'undefined` because Jest provides some kind of shim for `window`, and we want to run the tests in node.js conditions.