### PR TITLE
Do not assert current identity in dispatchAction

### DIFF
--- a/src/internals/dispatcher.js
+++ b/src/internals/dispatcher.js
@@ -250,7 +250,7 @@ function dispatchAction<A>(
   queue: UpdateQueue<A>,
   action: A
 ) {
-  if (componentIdentity === getCurrentIdentity()) {
+  if (componentIdentity === currentIdentity) {
     // This is a render phase update. Stash it in a lazily-created map of
     // queue -> linked list of updates. After this render pass, we'll restart
     // and apply the stashed updates on top of the work-in-progress hook.


### PR DESCRIPTION
Fixes #19

From what I can see, the `dispatchAction` function is bound with the first two arguments, to become (for example) a `setState` function. This `setState` function can be called at any time; it doesn't need to be (and actually should not be) called within the body of a function component.

Therefore, in `dispatchAction`, it doesn't make sense to make the assertion that `getCurrentIdentity()` makes:
https://github.com/FormidableLabs/react-ssr-prepass/blob/35fb629b99a7c608f795fa43f577ca7ba63fb192/src/internals/dispatcher.js#L26-L39

To prevent that assertion from happening inside `dispatchAction`, we can access `currentIdentity` directly.