### PR TITLE
React 18 alias useId, unstable_useId and unstable_useOpaqueIdentifier

### DIFF
--- a/src/internals/dispatcher.js
+++ b/src/internals/dispatcher.js
@@ -335,6 +335,8 @@ export const Dispatcher = {
   // aliased for now
   // see: https://github.com/FormidableLabs/react-ssr-prepass/pull/75
   useId: useOpaqueIdentifier,
+  unstable_useId: useOpaqueIdentifier,
+  unstable_useOpaqueIdentifier: useOpaqueIdentifier,
   // ignore useLayout effect completely as usage of it will be caught
   // in a subsequent render pass
   useLayoutEffect: noop,

--- a/src/internals/dispatcher.js
+++ b/src/internals/dispatcher.js
@@ -332,6 +332,9 @@ export const Dispatcher = {
   useTransition,
   useDeferredValue,
   useOpaqueIdentifier,
+  // aliased for now
+  // see: https://github.com/FormidableLabs/react-ssr-prepass/pull/75
+  useId: useOpaqueIdentifier,
   // ignore useLayout effect completely as usage of it will be caught
   // in a subsequent render pass
   useLayoutEffect: noop,


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/react-ssr-prepass/issues/74

I probably didn't need to break this out into another pull request did I haha