### PR TITLE
Ignore usage of useInsertionEffect (hook introduced in React 18) in dispatcher

### DIFF
--- a/src/internals/dispatcher.js
+++ b/src/internals/dispatcher.js
@@ -351,9 +351,10 @@ export const Dispatcher = {
   useId: useOpaqueIdentifier,
   unstable_useId: useOpaqueIdentifier,
   unstable_useOpaqueIdentifier: useOpaqueIdentifier,
-  // ignore useLayout effect completely as usage of it will be caught
+  // ignore useLayout / useInsertion effect completely as usage of it will be caught
   // in a subsequent render pass
   useLayoutEffect: noop,
+  useInsertionEffect: noop,
   // useImperativeHandle is not run in the server environment
   useImperativeHandle: noop,
   // Effects are not run in the server environment.


### PR DESCRIPTION
useInsertionEffect is a new hook introduced in React18 and can be an alternative way to useLayoutEffect to insert styles which does not run on the server.

useInsertionEffect: https://react.dev/reference/react/useInsertionEffect